### PR TITLE
zenx: common: add missing rules for accent picker

### DIFF
--- a/common/private/property_contexts
+++ b/common/private/property_contexts
@@ -3,3 +3,6 @@ persist.zenx.                           u:object_r:system_prop:s0
 ro.build.selinux              u:object_r:exported2_default_prop:s0
 ro.zenx.build.version.security_patch u:object_r:exported2_default_prop:s0
 ro.telephony.use_old_mnc_mcc_format      u:object_r:exported3_default_prop:s0
+
+# RGB Accent Picker
+persist.sys.theme.accentcolor    u:object_r:theme_prop:s0

--- a/common/private/system_app.te
+++ b/common/private/system_app.te
@@ -15,3 +15,7 @@ hal_client_domain(system_app, hal_lineage_touch)
 # Allow spectrum_prop to be read and set by Settings
 get_prop(system_app, spectrum_prop)
 set_prop(system_app, spectrum_prop)
+
+# Allow theme_prop to be read and set by Settings
+get_prop(system_app, theme_prop)
+set_prop(system_app, theme_prop)


### PR DESCRIPTION
Fixes the RGB accent picker crash.

Signed-off-by: Raaj52 <mail2raaj52@gmail.com>